### PR TITLE
Fixed bug when sending long key/value through RPC

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="kt4j" default="help" basedir=".">
 
-  <property name="version" value="0.7.0"/>
+  <property name="version" value="0.7.1"/>
 
   <property name="src.java.dir" value="src/java"/>
   <property name="src.test.dir" value="src/test"/>

--- a/src/java/kt4j/Bytes.java
+++ b/src/java/kt4j/Bytes.java
@@ -73,7 +73,7 @@ public class Bytes {
      */
     public static byte[] base64Encode(byte[] bytes) {
         ChannelBuffer src = ChannelBuffers.wrappedBuffer(bytes);
-        ChannelBuffer encodedBuff = Base64.encode(src);
+        ChannelBuffer encodedBuff = Base64.encode(src, false);
         byte[] encodedBytes = new byte[encodedBuff.readableBytes()];
         encodedBuff.readBytes(encodedBytes);
         return encodedBytes;

--- a/src/java/kt4j/tsvrpc/KyotoTycoonTsvRpcClient.java
+++ b/src/java/kt4j/tsvrpc/KyotoTycoonTsvRpcClient.java
@@ -20,12 +20,19 @@ import kt4j.AbstractKyotoTycoonClient;
  * @author kumai
  */
 public class KyotoTycoonTsvRpcClient extends AbstractKyotoTycoonClient {
+
     private String database;
-    
+    private TsvColumnCodec codec;
+
     public KyotoTycoonTsvRpcClient(String hostname, int port) {
-        super(new InetSocketAddress(hostname, port));
+        this(hostname, port, TsvColumnCodec.BASE_64);
     }
     
+    public KyotoTycoonTsvRpcClient(String hostname, int port, TsvColumnCodec codec) {
+        super(new InetSocketAddress(hostname, port));
+        this.codec = codec;
+    }
+
     /**
      * Sets the target database identifier.
      * 
@@ -38,7 +45,7 @@ public class KyotoTycoonTsvRpcClient extends AbstractKyotoTycoonClient {
     @Override
     public void set(byte[] key, byte[] value, ExpirationTime xt)
             throws KyotoTycoonOperationFailedException {
-        TsvRpcRequest request = TsvRpcRequest.createSet(key, value, xt);
+        TsvRpcRequest request = TsvRpcRequest.createSet(key, value, xt, codec);
         if (database != null) {
             request.setDatabaseIdentifier(database);
         }
@@ -58,14 +65,14 @@ public class KyotoTycoonTsvRpcClient extends AbstractKyotoTycoonClient {
     @Override
     public void setBulkString(Map<String, String> keyValuePairs, ExpirationTime xt, boolean atomic)
             throws KyotoTycoonOperationFailedException {
-        TsvRpcRequest request = TsvRpcRequest.createSetBulk(keyValuePairs, xt, atomic);
+        TsvRpcRequest request = TsvRpcRequest.createSetBulk(keyValuePairs, xt, atomic, codec);
         doSetBulk(request);
     }
 
     @Override
     public void setBulk(Map<byte[], byte[]> keyValuePairs, ExpirationTime xt, boolean atomic)
             throws KyotoTycoonOperationFailedException {
-        TsvRpcRequest request = TsvRpcRequest.createSetBulk(keyValuePairs, xt, atomic);
+        TsvRpcRequest request = TsvRpcRequest.createSetBulk(keyValuePairs, xt, atomic, codec);
         doSetBulk(request);
     }
     
@@ -88,7 +95,7 @@ public class KyotoTycoonTsvRpcClient extends AbstractKyotoTycoonClient {
 
     @Override
     public byte[] get(byte[] key) throws KyotoTycoonOperationFailedException {
-        TsvRpcRequest request = TsvRpcRequest.createGet(key);
+        TsvRpcRequest request = TsvRpcRequest.createGet(key, codec);
         if (database != null) {
             request.setDatabaseIdentifier(database);
         }
@@ -111,7 +118,7 @@ public class KyotoTycoonTsvRpcClient extends AbstractKyotoTycoonClient {
 
     @Override
     public byte[] seize(byte[] key) throws KyotoTycoonOperationFailedException {
-        TsvRpcRequest request = TsvRpcRequest.createSeize(key);
+        TsvRpcRequest request = TsvRpcRequest.createSeize(key, codec);
         if (database != null) {
             request.setDatabaseIdentifier(database);
         }
@@ -133,7 +140,7 @@ public class KyotoTycoonTsvRpcClient extends AbstractKyotoTycoonClient {
 
     @Override
     public boolean remove(byte[] key) throws KyotoTycoonOperationFailedException {
-        TsvRpcRequest request = TsvRpcRequest.createRemove(key);
+        TsvRpcRequest request = TsvRpcRequest.createRemove(key, codec);
         if (database != null) {
             request.setDatabaseIdentifier(database);
         }
@@ -156,7 +163,7 @@ public class KyotoTycoonTsvRpcClient extends AbstractKyotoTycoonClient {
     @Override
     public long increment(byte[] key, long num, long origin, ExpirationTime xt)
             throws KyotoTycoonOperationFailedException {
-        TsvRpcRequest request = TsvRpcRequest.createIncrement(key, num, origin, xt);
+        TsvRpcRequest request = TsvRpcRequest.createIncrement(key, num, origin, xt, codec);
         if (database != null) {
             request.setDatabaseIdentifier(database);
         }
@@ -197,7 +204,7 @@ public class KyotoTycoonTsvRpcClient extends AbstractKyotoTycoonClient {
     
     private double doIncrementDouble(byte[] key, double num, Double origin, ExpirationTime xt)
             throws KyotoTycoonOperationFailedException {
-        TsvRpcRequest request = TsvRpcRequest.createIncrementDouble(key, num, origin, xt);
+        TsvRpcRequest request = TsvRpcRequest.createIncrementDouble(key, num, origin, xt, codec);
         if (database != null) {
             request.setDatabaseIdentifier(database);
         }
@@ -227,7 +234,7 @@ public class KyotoTycoonTsvRpcClient extends AbstractKyotoTycoonClient {
     @Override
     public boolean cas(byte[] key, byte[] expect, byte[] update, ExpirationTime xt)
             throws KyotoTycoonOperationFailedException {
-        TsvRpcRequest request = TsvRpcRequest.createCas(key, expect, update, xt);
+        TsvRpcRequest request = TsvRpcRequest.createCas(key, expect, update, xt, codec);
         if (database != null) {
             request.setDatabaseIdentifier(database);
         }
@@ -249,7 +256,7 @@ public class KyotoTycoonTsvRpcClient extends AbstractKyotoTycoonClient {
     @Override
     public boolean replace(byte[] key, byte[] value, ExpirationTime xt)
             throws KyotoTycoonOperationFailedException {
-        TsvRpcRequest request = TsvRpcRequest.createReplace(key, value, xt);
+        TsvRpcRequest request = TsvRpcRequest.createReplace(key, value, xt, codec);
         if (database != null) {
             request.setDatabaseIdentifier(database);
         }
@@ -271,7 +278,7 @@ public class KyotoTycoonTsvRpcClient extends AbstractKyotoTycoonClient {
     @Override
     public boolean add(byte[] key, byte[] value, ExpirationTime xt)
             throws KyotoTycoonOperationFailedException {
-        TsvRpcRequest request = TsvRpcRequest.createAdd(key, value, xt);
+        TsvRpcRequest request = TsvRpcRequest.createAdd(key, value, xt, codec);
         if (database != null) {
             request.setDatabaseIdentifier(database);
         }
@@ -303,7 +310,7 @@ public class KyotoTycoonTsvRpcClient extends AbstractKyotoTycoonClient {
     @Override
     public Map<byte[], byte[]> getBulk(List<byte[]> keys, boolean atomic)
             throws KyotoTycoonOperationFailedException {
-        TsvRpcRequest request = TsvRpcRequest.createGetBulk(keys, atomic);
+        TsvRpcRequest request = TsvRpcRequest.createGetBulk(keys, atomic, codec);
         if (database != null) {
             request.setDatabaseIdentifier(database);
         }
@@ -322,7 +329,7 @@ public class KyotoTycoonTsvRpcClient extends AbstractKyotoTycoonClient {
     @Override
     public long removeBulk(List<byte[]> keys, boolean atomic)
             throws KyotoTycoonOperationFailedException {
-        TsvRpcRequest request = TsvRpcRequest.createRemoveBulk(keys, atomic);
+        TsvRpcRequest request = TsvRpcRequest.createRemoveBulk(keys, atomic, codec);
         if (database != null) {
             request.setDatabaseIdentifier(database);
         }
@@ -350,7 +357,7 @@ public class KyotoTycoonTsvRpcClient extends AbstractKyotoTycoonClient {
 
     @Override
     public void clear() throws KyotoTycoonOperationFailedException {
-        TsvRpcRequest request = TsvRpcRequest.createClear();
+        TsvRpcRequest request = TsvRpcRequest.createClear(codec);
         if (database != null) {
             request.setDatabaseIdentifier(database);
         }
@@ -365,7 +372,7 @@ public class KyotoTycoonTsvRpcClient extends AbstractKyotoTycoonClient {
     @Override
     public List<byte[]> matchRegex(byte[] regex, long max)
             throws KyotoTycoonOperationFailedException {
-        TsvRpcRequest request = TsvRpcRequest.createMatchRegex(regex, max);
+        TsvRpcRequest request = TsvRpcRequest.createMatchRegex(regex, max, codec);
         if (database != null) {
             request.setDatabaseIdentifier(database);
         }
@@ -382,7 +389,7 @@ public class KyotoTycoonTsvRpcClient extends AbstractKyotoTycoonClient {
     @Override
     public List<byte[]> matchPrefix(byte[] prefix, long max)
             throws KyotoTycoonOperationFailedException {
-        TsvRpcRequest request = TsvRpcRequest.createMatchPrefix(prefix, max);
+        TsvRpcRequest request = TsvRpcRequest.createMatchPrefix(prefix, max, codec);
         if (database != null) {
             request.setDatabaseIdentifier(database);
         }
@@ -399,7 +406,7 @@ public class KyotoTycoonTsvRpcClient extends AbstractKyotoTycoonClient {
     @Override
     public Map<byte[], byte[]> playScript(String procedureName, Map<byte[], byte[]> params)
             throws KyotoTycoonOperationFailedException {
-        Operation operation = call(TsvRpcRequest.createPlayScript(procedureName, params));
+        Operation operation = call(TsvRpcRequest.createPlayScript(procedureName, params, codec));
         TsvRpcResponse response = (TsvRpcResponse) operation.getResponse();
         if (operation.isSucceeded()) {
             Map<byte[], byte[]> result = response.getBulkResult();
@@ -413,7 +420,7 @@ public class KyotoTycoonTsvRpcClient extends AbstractKyotoTycoonClient {
 
     @Override
     public void ping() throws KyotoTycoonOperationFailedException {
-        TsvRpcRequest request = TsvRpcRequest.createVoid();
+        TsvRpcRequest request = TsvRpcRequest.createVoid(codec);
         if (database != null) {
             request.setDatabaseIdentifier(database);
         }
@@ -427,7 +434,7 @@ public class KyotoTycoonTsvRpcClient extends AbstractKyotoTycoonClient {
 
     @Override
     public void synchronize(boolean hard, String command) throws KyotoTycoonOperationFailedException {
-        TsvRpcRequest request = TsvRpcRequest.createSynchronize(hard, command);
+        TsvRpcRequest request = TsvRpcRequest.createSynchronize(hard, command, codec);
         if (database != null) {
             request.setDatabaseIdentifier(database);
         }
@@ -447,7 +454,7 @@ public class KyotoTycoonTsvRpcClient extends AbstractKyotoTycoonClient {
 
     @Override
     public void vacuum(int step) throws KyotoTycoonOperationFailedException {
-        TsvRpcRequest request = TsvRpcRequest.createVacuum(step);
+        TsvRpcRequest request = TsvRpcRequest.createVacuum(step, codec);
         if (database != null) {
             request.setDatabaseIdentifier(database);
         }
@@ -462,7 +469,7 @@ public class KyotoTycoonTsvRpcClient extends AbstractKyotoTycoonClient {
 
     @Override
     public Map<String, String> getStatus() throws KyotoTycoonOperationFailedException {
-        TsvRpcRequest request = TsvRpcRequest.createStatus();
+        TsvRpcRequest request = TsvRpcRequest.createStatus(codec);
         if (database != null) {
             request.setDatabaseIdentifier(database);
         }
@@ -477,7 +484,7 @@ public class KyotoTycoonTsvRpcClient extends AbstractKyotoTycoonClient {
 
     @Override
     public Map<String, String> getReport() throws KyotoTycoonOperationFailedException {
-        TsvRpcRequest request = TsvRpcRequest.createReport();
+        TsvRpcRequest request = TsvRpcRequest.createReport(codec);
         Operation operation = call(request);
         TsvRpcResponse response = (TsvRpcResponse) operation.getResponse();
         if (response == null || response.status != 200) {
@@ -490,7 +497,7 @@ public class KyotoTycoonTsvRpcClient extends AbstractKyotoTycoonClient {
     @Override
     public Map<byte[], byte[]> echo(Map<byte[], byte[]> input)
             throws KyotoTycoonOperationFailedException {
-        TsvRpcRequest request = TsvRpcRequest.createEcho(input);
+        TsvRpcRequest request = TsvRpcRequest.createEcho(input, codec);
         Operation operation = call(request);
         TsvRpcResponse response = (TsvRpcResponse) operation.getResponse();
         if (response == null || response.status != 200) {
@@ -503,7 +510,7 @@ public class KyotoTycoonTsvRpcClient extends AbstractKyotoTycoonClient {
     @Override
     public Map<String, String> echoString(Map<String, String> input)
             throws KyotoTycoonOperationFailedException {
-        TsvRpcRequest request = TsvRpcRequest.createEcho(input);
+        TsvRpcRequest request = TsvRpcRequest.createEcho(input, codec);
         Operation operation = call(request);
         TsvRpcResponse response = (TsvRpcResponse) operation.getResponse();
         if (response == null || response.status != 200) {

--- a/src/java/kt4j/tsvrpc/TsvColumnCodec.java
+++ b/src/java/kt4j/tsvrpc/TsvColumnCodec.java
@@ -13,7 +13,7 @@ import kt4j.Bytes;
  * @author kumai
  *
  */
-enum TsvColumnCodec {
+public enum TsvColumnCodec {
 
     BASE_64("text/tab-separated-values; colenc=B") {
         @Override

--- a/src/java/kt4j/tsvrpc/TsvRpcRequest.java
+++ b/src/java/kt4j/tsvrpc/TsvRpcRequest.java
@@ -18,7 +18,6 @@ import kt4j.Request;
  *
  */
 class TsvRpcRequest extends Request {
-    private final TsvColumnCodec columnCodec = TsvColumnCodec.BASE_64;
     
     private static final String KEY = "key";
     private static final String VALUE = "value";
@@ -32,11 +31,19 @@ class TsvRpcRequest extends Request {
     private static final byte[] EMPTY_VALUE = new byte[0];
     
     private final Map<Object, Object> values = new HashMap<Object, Object>();
+
+    private TsvColumnCodec columnCodec;
     
     TsvRpcRequest(Command operation) {
+        this(operation, TsvColumnCodec.NONE);
+    }
+
+    TsvRpcRequest(Command operation, TsvColumnCodec codec) {
         super(operation);
+        this.columnCodec = codec;
     }
     
+
     public void setDatabaseIdentifier(String db) {
         if (db != null) {
             values.put("DB", utf8(db));
@@ -74,14 +81,14 @@ class TsvRpcRequest extends Request {
         return out.toByteArray();
     }
     
-    static TsvRpcRequest createGet(byte[] key) {
-        TsvRpcRequest request = new TsvRpcRequest(Command.GET);
+    static TsvRpcRequest createGet(byte[] key, TsvColumnCodec codec) {
+        TsvRpcRequest request = new TsvRpcRequest(Command.GET, codec);
         request.setRpcParam(KEY, key);
         return request;
     }
     
-    static TsvRpcRequest createGetBulk(List<byte[]> keys, boolean atomic) {
-        TsvRpcRequest request = new TsvRpcRequest(Command.GET_BULK);
+    static TsvRpcRequest createGetBulk(List<byte[]> keys, boolean atomic, TsvColumnCodec codec) {
+        TsvRpcRequest request = new TsvRpcRequest(Command.GET_BULK, codec);
         
         if (atomic) {
             request.setRpcParam(ATOMIC, EMPTY_VALUE);
@@ -97,8 +104,8 @@ class TsvRpcRequest extends Request {
         return request;
     }
     
-    static TsvRpcRequest createSet(byte[] key, byte[] value, ExpirationTime xt) {
-        TsvRpcRequest request = new TsvRpcRequest(Command.SET);
+    static TsvRpcRequest createSet(byte[] key, byte[] value, ExpirationTime xt, TsvColumnCodec codec) {
+        TsvRpcRequest request = new TsvRpcRequest(Command.SET, codec);
         request.setRpcParam(KEY, key);
         request.setRpcParam(VALUE, value);
         if (xt != null) {
@@ -107,8 +114,8 @@ class TsvRpcRequest extends Request {
         return request;
     }
     
-    static TsvRpcRequest createSetBulk(Map<?, ?> keyValuePairs, ExpirationTime xt, boolean atomic) {
-        TsvRpcRequest request = new TsvRpcRequest(Command.SET_BULK);
+    static TsvRpcRequest createSetBulk(Map<?, ?> keyValuePairs, ExpirationTime xt, boolean atomic, TsvColumnCodec codec) {
+        TsvRpcRequest request = new TsvRpcRequest(Command.SET_BULK, codec);
         
         if (xt != null) {
             request.setRpcParam(XT, xt.toString());
@@ -130,14 +137,14 @@ class TsvRpcRequest extends Request {
         return request;
     }
     
-    static TsvRpcRequest createRemove(byte[] key) {
-        TsvRpcRequest request = new TsvRpcRequest(Command.REMOVE);
+    static TsvRpcRequest createRemove(byte[] key, TsvColumnCodec codec) {
+        TsvRpcRequest request = new TsvRpcRequest(Command.REMOVE, codec);
         request.setRpcParam(KEY, key);
         return request;
     }
     
-    static TsvRpcRequest createRemoveBulk(List<byte[]> keys, boolean atomic) {
-        TsvRpcRequest request = new TsvRpcRequest(Command.REMOVE_BULK);
+    static TsvRpcRequest createRemoveBulk(List<byte[]> keys, boolean atomic, TsvColumnCodec codec) {
+        TsvRpcRequest request = new TsvRpcRequest(Command.REMOVE_BULK, codec);
         
         if (atomic) {
             request.setRpcParam(ATOMIC, EMPTY_VALUE);
@@ -153,8 +160,8 @@ class TsvRpcRequest extends Request {
         return request;
     }
     
-    static final TsvRpcRequest createIncrement(byte[] key, long num, long origin, ExpirationTime xt) {
-        TsvRpcRequest request = new TsvRpcRequest(Command.INCREMENT);
+    static final TsvRpcRequest createIncrement(byte[] key, long num, long origin, ExpirationTime xt, TsvColumnCodec codec) {
+        TsvRpcRequest request = new TsvRpcRequest(Command.INCREMENT, codec);
         request.setRpcParam(KEY, key);
         request.setRpcParam(NUM, String.valueOf(num));
         request.setRpcParam(ORIG, String.valueOf(origin));
@@ -166,8 +173,8 @@ class TsvRpcRequest extends Request {
         return request;
     }
     
-    static TsvRpcRequest createIncrementDouble(byte[] key, double num, Double origin, ExpirationTime xt) {
-        TsvRpcRequest request = new TsvRpcRequest(Command.INCREMENT_DOUBLE);
+    static TsvRpcRequest createIncrementDouble(byte[] key, double num, Double origin, ExpirationTime xt, TsvColumnCodec codec) {
+        TsvRpcRequest request = new TsvRpcRequest(Command.INCREMENT_DOUBLE, codec);
         request.setRpcParam(KEY, key);
         request.setRpcParam(NUM, String.valueOf(num));
         
@@ -188,8 +195,8 @@ class TsvRpcRequest extends Request {
         return request;
     }
 
-    static TsvRpcRequest createCas(byte[] key, byte[] expect, byte[] update, ExpirationTime xt) {
-        TsvRpcRequest request = new TsvRpcRequest(Command.CAS);
+    static TsvRpcRequest createCas(byte[] key, byte[] expect, byte[] update, ExpirationTime xt, TsvColumnCodec codec) {
+        TsvRpcRequest request = new TsvRpcRequest(Command.CAS, codec);
         request.setRpcParam(KEY, key);
         request.setRpcParam(OVAL, expect);
         request.setRpcParam(NVAL, update);
@@ -201,31 +208,19 @@ class TsvRpcRequest extends Request {
         return request;
     }
     
-    static TsvRpcRequest createClear() {
-        TsvRpcRequest request = new TsvRpcRequest(Command.CLEAR);
+    static TsvRpcRequest createClear(TsvColumnCodec codec) {
+        TsvRpcRequest request = new TsvRpcRequest(Command.CLEAR, codec);
         return request;
     }
     
-    static TsvRpcRequest createSeize(byte[] key) {
-        TsvRpcRequest request = new TsvRpcRequest(Command.SEIZE);
+    static TsvRpcRequest createSeize(byte[] key, TsvColumnCodec codec) {
+        TsvRpcRequest request = new TsvRpcRequest(Command.SEIZE, codec);
         request.setRpcParam(KEY, key);
         return request;
     }
     
-    static TsvRpcRequest createReplace(byte[] key, byte[] value, ExpirationTime xt) {
-        TsvRpcRequest request = new TsvRpcRequest(Command.REPLACE);
-        request.setRpcParam(KEY, key);
-        request.setRpcParam(VALUE, value);
-        
-        if (xt != null) {
-            request.setRpcParam(XT, xt.toString());
-        }
-        
-        return request;
-    }
-    
-    static TsvRpcRequest createAdd(byte[] key, byte[] value, ExpirationTime xt) {
-        TsvRpcRequest request = new TsvRpcRequest(Command.ADD);
+    static TsvRpcRequest createReplace(byte[] key, byte[] value, ExpirationTime xt, TsvColumnCodec codec) {
+        TsvRpcRequest request = new TsvRpcRequest(Command.REPLACE, codec);
         request.setRpcParam(KEY, key);
         request.setRpcParam(VALUE, value);
         
@@ -236,8 +231,20 @@ class TsvRpcRequest extends Request {
         return request;
     }
     
-    static TsvRpcRequest createMatchPrefix(byte[] prefix, long max) {
-        TsvRpcRequest request = new TsvRpcRequest(Command.MATCH_PREFIX);
+    static TsvRpcRequest createAdd(byte[] key, byte[] value, ExpirationTime xt, TsvColumnCodec codec) {
+        TsvRpcRequest request = new TsvRpcRequest(Command.ADD, codec);
+        request.setRpcParam(KEY, key);
+        request.setRpcParam(VALUE, value);
+        
+        if (xt != null) {
+            request.setRpcParam(XT, xt.toString());
+        }
+        
+        return request;
+    }
+    
+    static TsvRpcRequest createMatchPrefix(byte[] prefix, long max, TsvColumnCodec codec) {
+        TsvRpcRequest request = new TsvRpcRequest(Command.MATCH_PREFIX, codec);
         request.setRpcParam("prefix", prefix);
         if (max > -1) {
             request.setRpcParam("max", String.valueOf(max));
@@ -245,8 +252,8 @@ class TsvRpcRequest extends Request {
         return request;
     }
     
-    static TsvRpcRequest createMatchRegex(byte[] regex, long max) {
-        TsvRpcRequest request = new TsvRpcRequest(Command.MATCH_REGEX);
+    static TsvRpcRequest createMatchRegex(byte[] regex, long max, TsvColumnCodec codec) {
+        TsvRpcRequest request = new TsvRpcRequest(Command.MATCH_REGEX, codec);
         request.setRpcParam("regex", regex);
         if (max > -1) {
             request.setRpcParam("max", String.valueOf(max));
@@ -254,8 +261,8 @@ class TsvRpcRequest extends Request {
         return request;
     }
     
-    static TsvRpcRequest createPlayScript(String procedureName, Map<byte[], ?> params) {
-        TsvRpcRequest request = new TsvRpcRequest(Command.PLAY_SCRIPT);
+    static TsvRpcRequest createPlayScript(String procedureName, Map<byte[], ?> params, TsvColumnCodec codec) {
+        TsvRpcRequest request = new TsvRpcRequest(Command.PLAY_SCRIPT, codec);
         request.setRpcParam("name", procedureName);
         if (params != null) {
             for (Map.Entry<byte[], ?> kv : params.entrySet()) {
@@ -268,13 +275,13 @@ class TsvRpcRequest extends Request {
         return request;
     }
     
-    static TsvRpcRequest createVoid() {
-        TsvRpcRequest request = new TsvRpcRequest(Command.VOID);
+    static TsvRpcRequest createVoid(TsvColumnCodec codec) {
+        TsvRpcRequest request = new TsvRpcRequest(Command.VOID, codec);
         return request;
     }
 
-    static TsvRpcRequest createSynchronize(boolean hard, String command) {
-        TsvRpcRequest request = new TsvRpcRequest(Command.SYNCHRONIZE);
+    static TsvRpcRequest createSynchronize(boolean hard, String command, TsvColumnCodec codec) {
+        TsvRpcRequest request = new TsvRpcRequest(Command.SYNCHRONIZE, codec);
         if (hard) {
             request.setRpcParam("hard", EMPTY_VALUE);
         }
@@ -284,24 +291,24 @@ class TsvRpcRequest extends Request {
         return request;
     }
 
-    static TsvRpcRequest createVacuum(int step) {
-        TsvRpcRequest request = new TsvRpcRequest(Command.VACUUM);
+    static TsvRpcRequest createVacuum(int step, TsvColumnCodec codec) {
+        TsvRpcRequest request = new TsvRpcRequest(Command.VACUUM, codec);
         request.setRpcParam("step", String.valueOf(step));
         return request;
     }
 
-    static TsvRpcRequest createStatus() {
-        TsvRpcRequest request = new TsvRpcRequest(Command.STATUS);
+    static TsvRpcRequest createStatus(TsvColumnCodec codec) {
+        TsvRpcRequest request = new TsvRpcRequest(Command.STATUS, codec);
         return request;
     }
 
-    static TsvRpcRequest createReport() {
-        TsvRpcRequest request = new TsvRpcRequest(Command.REPORT);
+    static TsvRpcRequest createReport(TsvColumnCodec codec) {
+        TsvRpcRequest request = new TsvRpcRequest(Command.REPORT, codec);
         return request;
     }
 
-    static TsvRpcRequest createEcho(Map<?, ?> input) {
-        TsvRpcRequest request = new TsvRpcRequest(Command.ECHO);
+    static TsvRpcRequest createEcho(Map<?, ?> input, TsvColumnCodec codec) {
+        TsvRpcRequest request = new TsvRpcRequest(Command.ECHO, codec);
         for (Map.Entry<?, ?> entry : input.entrySet()) {
             request.setRpcParam(entry.getKey(), entry.getValue());
         }


### PR DESCRIPTION
The method `Bytes.base64Encode()` encodes the input using `Base64.decode` with `breaklines` option enabled by default. If the input is long enough, the returning value will contain '\n' character which breaks the parser on server side. To reproduce this bug, simply set a key longer than 57 bytes with `KyotoTycoonTsvRpcClient` and try to receive it with `ktremotemgr get`. This pull request is to make that option disabled by default. 

We should also allow user to choose the codec when creating KyotoTycoonTsvRpcClient, and it should be `TsvColumnCodec.NONE` (i.e sending it as is) by default as it saves some HTTP traffic compared to `TsvColumnCodec.Base64`. This is useful when user knows that their keys are always in ASCII. 
